### PR TITLE
Update .asoundrc

### DIFF
--- a/audio-drivers/USB-MIC-JACK/scripts/.asoundrc
+++ b/audio-drivers/USB-MIC-JACK/scripts/.asoundrc
@@ -4,7 +4,7 @@ pcm.dsnooper {
     ipc_key_add_uid 0
     ipc_perm 0666
     slave {
-        pcm "hw:1,0"
+        pcm "hw:2,0"
         channels 1
     }
 }
@@ -13,7 +13,7 @@ pcm.!default {
         type asym
         playback.pcm {
                 type plug
-                slave.pcm "hw:0,0"
+                slave.pcm "hw:1,0"
         }
         capture.pcm {
                 type plug


### PR DESCRIPTION
Change from hw. 0.0 to hw 2.0 on Buster when USB is connected
See command
 cat /proc/asound/cards

```
 0 [b1             ]: bcm2835_hdmi - bcm2835 HDMI 1
                      bcm2835 HDMI 1
 1 [Headphones     ]: bcm2835_headphonbcm2835 Headphones - bcm2835 Headphones
                      bcm2835 Headphones
 2 [CameraB409241  ]: USB-Audio - USB Camera-B4.09.24.1
                      OmniVision Technologies, Inc. USB Camera-B4.09.24.1 at usb-3f980000.usb-1.2.3,
```

```